### PR TITLE
Added class_weight parameter to sparse_categorical_focal_loss

### DIFF
--- a/src/focal_loss/_categorical_focal_loss.py
+++ b/src/focal_loss/_categorical_focal_loss.py
@@ -209,6 +209,10 @@ class SparseCategoricalFocalLoss(tf.keras.losses.Loss):
         one-dimensional tensor, in which case it specifies a focusing parameter
         for each class.
 
+    class_weight: tensor-like of shape (K,)
+        Weighting factor for each of the :math:`k` classes. If not specified,
+        then all classes are weighted equally.
+
     from_logits : bool, optional
         Whether model prediction will be logits or probabilities.
 
@@ -254,9 +258,11 @@ class SparseCategoricalFocalLoss(tf.keras.losses.Loss):
         tensor and a prediction tensor and outputting a loss.
     """
 
-    def __init__(self, gamma, from_logits: bool = False, **kwargs):
+    def __init__(self, gamma, class_weight: Optional[Any] = None,
+                 from_logits: bool = False, **kwargs):
         super().__init__(**kwargs)
         self.gamma = gamma
+        self.class_weight = class_weight
         self.from_logits = from_logits
 
     def get_config(self):
@@ -272,7 +278,8 @@ class SparseCategoricalFocalLoss(tf.keras.losses.Loss):
             This layer's config.
         """
         config = super().get_config()
-        config.update(gamma=self.gamma, from_logits=self.from_logits)
+        config.update(gamma=self.gamma, class_weight=self.class_weight,
+                      from_logits=self.from_logits)
         return config
 
     def call(self, y_true, y_pred):
@@ -299,5 +306,6 @@ class SparseCategoricalFocalLoss(tf.keras.losses.Loss):
             :meth:`~focal_loss.SparseCateogiricalFocalLoss.__call__` method.
         """
         return sparse_categorical_focal_loss(y_true=y_true, y_pred=y_pred,
+                                             class_weight=self.class_weight,
                                              gamma=self.gamma,
                                              from_logits=self.from_logits)

--- a/src/focal_loss/tests/test_sparse_categorical_focal_loss.py
+++ b/src/focal_loss/tests/test_sparse_categorical_focal_loss.py
@@ -355,4 +355,27 @@ class SparseCategoricalFocalLossTest(parameterized.TestCase, tf.test.TestCase):
 
         self.assertAllClose(loss, loss_numpy)
 
+    @named_parameters_with_testcase_names(y_true=Y_TRUE, y_pred=Y_PRED_PROB,
+                                          gamma=[0, 1, 2])
+    def test_class_weight(self, y_true, y_pred, gamma):
+        rng = np.random.default_rng(0)
+        for _ in range(10):
+            class_weight = rng.uniform(size=np.shape(y_pred)[-1])
 
+            loss_without_weight = sparse_categorical_focal_loss(
+                y_true=y_true,
+                y_pred=y_pred,
+                gamma=gamma,
+            )
+            loss_with_weight = sparse_categorical_focal_loss(
+                y_true=y_true,
+                y_pred=y_pred,
+                gamma=gamma,
+                class_weight=class_weight,
+            )
+
+            # Apply class weights to loss computed without class_weight
+            loss_without_weight = loss_without_weight.numpy()
+            loss_without_weight *= np.take(class_weight, y_true)
+
+            self.assertAllClose(loss_with_weight, loss_without_weight)


### PR DESCRIPTION
Similar to the `pos_weight` parameter of `binary_focal_loss`, `class_weight` allows the user to specify the relative weight of each class.