### PR TITLE
0.0.7->0.0.8 version bump

### DIFF
--- a/src/focal_loss/__init__.py
+++ b/src/focal_loss/__init__.py
@@ -5,7 +5,7 @@ from ._categorical_focal_loss import SparseCategoricalFocalLoss
 
 # Package information
 __package__ = 'focal-loss'
-__version__ = '0.0.7'
+__version__ = '0.0.8'
 __author__ = 'Artem Mavrin'
 __author_email__ = 'artemvmavrin@gmail.com'
 __description__ = 'TensorFlow implementation of focal loss.'


### PR DESCRIPTION
Uploaded `focal-loss` version 0.0.7 to PyPI to expose the `class_weight` argument introduction for `sparse_categorical_focal_loss`.